### PR TITLE
fix: improve dark mode text readability in movie details badges and sections

### DIFF
--- a/app/components/details/MovieDetails.tsx
+++ b/app/components/details/MovieDetails.tsx
@@ -155,7 +155,7 @@ export function MovieDetails({
       >
         <Link
           to="/"
-          className="inline-flex items-center justify-center w-16 h-16 rounded-full text-gray-700 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 transition-all duration-300 transform hover:scale-110 hover:rotate-12"
+          className="inline-flex items-center justify-center w-16 h-16 rounded-full text-gray-700 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 transition-all duration-300 transform hover:scale-110 hover:rotate-12"
           aria-label="Go back to search"
         >
           <ArrowLeftIcon className="w-10 h-10" />
@@ -262,7 +262,7 @@ export function MovieDetails({
                 animate={{ opacity: 1, scale: 1 }}
                 transition={{ delay: 0.7 }}
               >
-                <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4 flex items-center gap-2">
+                <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-800 mb-4 flex items-center gap-2">
                   <StarIcon className="w-5 h-5 text-yellow-500" />
                   Ratings & Reviews
                 </h3>
@@ -270,7 +270,7 @@ export function MovieDetails({
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-2">
                       <StarIcon className="w-5 h-5 text-yellow-500" />
-                      <span className="font-semibold text-gray-900 dark:text-white">
+                      <span className="font-semibold text-gray-900 dark:text-gray-800">
                         IMDb Rating
                       </span>
                     </div>
@@ -282,10 +282,10 @@ export function MovieDetails({
                   </div>
                   {movie.imdbVotes && movie.imdbVotes !== 'N/A' && (
                     <div className="flex items-center justify-between">
-                      <span className="text-gray-600 dark:text-gray-400">
+                      <span className="text-gray-600 dark:text-gray-800 font-bold">
                         Total Votes
                       </span>
-                      <span className="font-semibold text-gray-900 dark:text-white">
+                      <span className="font-semibold text-gray-900 dark:text-gray-800">
                         {parseInt(movie.imdbVotes).toLocaleString()}
                       </span>
                     </div>
@@ -294,7 +294,7 @@ export function MovieDetails({
                     <div className="flex items-center justify-between">
                       <div className="flex items-center gap-2">
                         <ChartBarIcon className="w-5 h-5 text-green-500" />
-                        <span className="font-semibold text-gray-900 dark:text-white">
+                        <span className="font-semibold text-gray-900 dark:text-gray-800">
                           Metascore
                         </span>
                       </div>
@@ -322,7 +322,7 @@ export function MovieDetails({
                   Synopsis
                 </h3>
                 <div className="bg-gray-50 dark:bg-gray-700/50 p-6 rounded-xl border border-gray-200 dark:border-gray-600">
-                  <p className="text-gray-700 dark:text-gray-300 leading-relaxed text-lg">
+                  <p className="text-gray-700 dark:text-gray-400 leading-relaxed text-lg">
                     {movie.Plot}
                   </p>
                 </div>
@@ -340,11 +340,11 @@ export function MovieDetails({
               <div className="space-y-6">
                 {movie.Genre && movie.Genre !== 'N/A' && (
                   <div className="bg-blue-50 dark:bg-blue-900/20 p-4 rounded-xl border border-blue-200 dark:border-blue-800">
-                    <h4 className="font-semibold text-gray-900 dark:text-white mb-2 flex items-center gap-2">
+                    <h4 className="font-semibold text-gray-900 dark:text-gray-800 mb-2 flex items-center gap-2">
                       <TagIcon className="w-5 h-5 text-blue-500" />
                       Genre
                     </h4>
-                    <p className="text-gray-700 dark:text-gray-300">
+                    <p className="text-gray-700 dark:text-gray-400">
                       {movie.Genre}
                     </p>
                   </div>
@@ -352,11 +352,11 @@ export function MovieDetails({
 
                 {movie.Director && movie.Director !== 'N/A' && (
                   <div className="bg-green-50 dark:bg-green-900/20 p-4 rounded-xl border border-green-200 dark:border-green-800">
-                    <h4 className="font-semibold text-gray-900 dark:text-white mb-2 flex items-center gap-2">
+                    <h4 className="font-semibold text-gray-900 dark:text-gray-800 mb-2 flex items-center gap-2">
                       <VideoCameraIcon className="w-5 h-5 text-green-500" />
                       Director
                     </h4>
-                    <p className="text-gray-700 dark:text-gray-300">
+                    <p className="text-gray-700 dark:text-gray-400">
                       {movie.Director}
                     </p>
                   </div>
@@ -364,11 +364,11 @@ export function MovieDetails({
 
                 {movie.Writer && movie.Writer !== 'N/A' && (
                   <div className="bg-purple-50 dark:bg-purple-900/20 p-4 rounded-xl border border-purple-200 dark:border-purple-800">
-                    <h4 className="font-semibold text-gray-900 dark:text-white mb-2 flex items-center gap-2">
+                    <h4 className="font-semibold text-gray-900 dark:text-gray-800 mb-2 flex items-center gap-2">
                       <PencilIcon className="w-5 h-5 text-purple-500" />
                       Writer
                     </h4>
-                    <p className="text-gray-700 dark:text-gray-300">
+                    <p className="text-gray-700 dark:text-gray-400">
                       {movie.Writer}
                     </p>
                   </div>
@@ -379,11 +379,11 @@ export function MovieDetails({
               <div className="space-y-6">
                 {movie.Actors && movie.Actors !== 'N/A' && (
                   <div className="bg-orange-50 dark:bg-orange-900/20 p-4 rounded-xl border border-orange-200 dark:border-orange-800">
-                    <h4 className="font-semibold text-gray-900 dark:text-white mb-2 flex items-center gap-2">
+                    <h4 className="font-semibold text-gray-900 dark:text-gray-800 mb-2 flex items-center gap-2">
                       <UserGroupIcon className="w-5 h-5 text-orange-500" />
                       Cast
                     </h4>
-                    <p className="text-gray-700 dark:text-gray-300">
+                    <p className="text-gray-700 dark:text-gray-400">
                       {movie.Actors}
                     </p>
                   </div>
@@ -391,11 +391,11 @@ export function MovieDetails({
 
                 {movie.Production && movie.Production !== 'N/A' && (
                   <div className="bg-indigo-50 dark:bg-indigo-900/20 p-4 rounded-xl border border-indigo-200 dark:border-indigo-800">
-                    <h4 className="font-semibold text-gray-900 dark:text-white mb-2 flex items-center gap-2">
+                    <h4 className="font-semibold text-gray-900 dark:text-gray-800 mb-2 flex items-center gap-2">
                       <BuildingOfficeIcon className="w-5 h-5 text-indigo-500" />
                       Production
                     </h4>
-                    <p className="text-gray-700 dark:text-gray-300">
+                    <p className="text-gray-700 dark:text-gray-400">
                       {movie.Production}
                     </p>
                   </div>
@@ -412,35 +412,35 @@ export function MovieDetails({
                 transition={{ delay: 1.0 }}
               >
                 <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-6 flex items-center gap-2">
-                  <UserIcon className="w-5 h-5 text-gray-500" />
+                  <UserIcon className="w-5 h-5" />
                   Additional Information
                 </h3>
                 <div className="grid md:grid-cols-3 gap-6">
                   {movie.BoxOffice && movie.BoxOffice !== 'N/A' && (
                     <div className="bg-emerald-50 dark:bg-emerald-900/20 p-4 rounded-xl border border-emerald-200 dark:border-emerald-800">
-                      <h4 className="font-semibold text-gray-900 dark:text-white mb-2 flex items-center gap-2">
+                      <h4 className="font-semibold text-gray-900 dark:text-gray-800 mb-2 flex items-center gap-2">
                         <CurrencyDollarIcon className="w-5 h-5 text-emerald-500" />
                         Box Office
                       </h4>
-                      <p className="text-gray-700 dark:text-gray-300 font-medium">
+                      <p className="text-gray-700 dark:text-gray-400 font-medium">
                         {movie.BoxOffice}
                       </p>
                     </div>
                   )}
                   {movie.DVD && movie.DVD !== 'N/A' && (
                     <div className="bg-pink-50 dark:bg-pink-900/20 p-4 rounded-xl border border-pink-200 dark:border-pink-800">
-                      <h4 className="font-semibold text-gray-900 dark:text-white mb-2 flex items-center gap-2">
+                      <h4 className="font-semibold text-gray-900 dark:text-gray-800 mb-2 flex items-center gap-2">
                         <ComputerDesktopIcon className="w-5 h-5 text-pink-500" />
                         DVD Release
                       </h4>
-                      <p className="text-gray-700 dark:text-gray-300">
+                      <p className="text-gray-700 dark:text-gray-400">
                         {movie.DVD}
                       </p>
                     </div>
                   )}
                   {movie.Website && movie.Website !== 'N/A' && (
                     <div className="bg-cyan-50 dark:bg-cyan-900/20 p-4 rounded-xl border border-cyan-200 dark:border-cyan-800">
-                      <h4 className="font-semibold text-gray-900 dark:text-white mb-2 flex items-center gap-2">
+                      <h4 className="font-semibold text-gray-900 dark:text-gray-800 mb-2 flex items-center gap-2">
                         <GlobeAltIcon className="w-5 h-5 text-cyan-500" />
                         Official Website
                       </h4>

--- a/app/components/search/EmptyState.tsx
+++ b/app/components/search/EmptyState.tsx
@@ -18,4 +18,4 @@ export function EmptyState({ className = '' }: EmptyStateProps) {
       </div>
     </div>
   );
-} 
+}

--- a/app/components/search/MovieCard.tsx
+++ b/app/components/search/MovieCard.tsx
@@ -24,8 +24,10 @@ export function MovieCard({
       series: { icon: '📺', label: 'Series' },
       episode: { icon: '📺', label: 'Episode' },
     };
-    
-    return typeMap[type as keyof typeof typeMap] || { icon: '🎭', label: 'Other' };
+
+    return (
+      typeMap[type as keyof typeof typeMap] || { icon: '🎭', label: 'Other' }
+    );
   };
 
   const handleMouseEnter = () => {

--- a/app/components/search/MovieList.tsx
+++ b/app/components/search/MovieList.tsx
@@ -53,14 +53,14 @@ function ResultsCount({ totalResults }: { totalResults: number }) {
 }
 
 // Load more button component
-function LoadMoreButton({ 
-  onLoadMore, 
-  loading, 
-  hasMore 
-}: { 
-  onLoadMore: () => void; 
-  loading: boolean; 
-  hasMore: boolean; 
+function LoadMoreButton({
+  onLoadMore,
+  loading,
+  hasMore,
+}: {
+  onLoadMore: () => void;
+  loading: boolean;
+  hasMore: boolean;
 }) {
   if (!hasMore) return null;
 
@@ -122,16 +122,20 @@ export function MovieList({
   return (
     <div className={className}>
       <ResultsCount totalResults={totalResults} />
-      
+
       <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
         {movies.map((movie, index) => (
           <MovieCard key={movie.imdbID} movie={movie} index={index} />
         ))}
-        
+
         {loading && movies.length > 0 && hasMore && <LoadingSkeleton />}
       </div>
 
-      <LoadMoreButton onLoadMore={onLoadMore} loading={loading} hasMore={hasMore} />
+      <LoadMoreButton
+        onLoadMore={onLoadMore}
+        loading={loading}
+        hasMore={hasMore}
+      />
     </div>
   );
 }

--- a/app/components/search/MovieNotFound.tsx
+++ b/app/components/search/MovieNotFound.tsx
@@ -18,4 +18,4 @@ export function MovieNotFound({ className = '' }: MovieNotFoundProps) {
       </div>
     </div>
   );
-} 
+}

--- a/app/components/search/SearchInput.tsx
+++ b/app/components/search/SearchInput.tsx
@@ -33,25 +33,32 @@ export function SearchInput({
     onClear();
   };
 
-  const getFilterButtonClasses = (buttonType: SearchParams['type'], currentType: SearchParams['type']) => {
+  const getFilterButtonClasses = (
+    buttonType: SearchParams['type'],
+    currentType: SearchParams['type']
+  ) => {
     const isActive = buttonType === currentType;
-    const baseClasses = 'px-6 py-3 text-sm font-medium rounded-xl border-2 transition-all duration-300';
-    
+    const baseClasses =
+      'px-6 py-3 text-sm font-medium rounded-xl border-2 transition-all duration-300';
+
     if (isActive) {
       const colorMap = {
-        undefined: 'bg-blue-600 text-white border-blue-600 shadow-lg shadow-blue-500/30 dark:shadow-blue-400/30',
-        movie: 'bg-green-600 text-white border-green-600 shadow-lg shadow-green-500/30 dark:shadow-green-400/30',
-        series: 'bg-purple-600 text-white border-purple-600 shadow-lg shadow-purple-500/30 dark:shadow-purple-400/30',
+        undefined:
+          'bg-blue-600 text-white border-blue-600 shadow-lg shadow-blue-500/30 dark:shadow-blue-400/30',
+        movie:
+          'bg-green-600 text-white border-green-600 shadow-lg shadow-green-500/30 dark:shadow-green-400/30',
+        series:
+          'bg-purple-600 text-white border-purple-600 shadow-lg shadow-purple-500/30 dark:shadow-purple-400/30',
       };
       return `${baseClasses} ${colorMap[buttonType as keyof typeof colorMap]}`;
     }
-    
+
     const hoverColorMap = {
       undefined: 'hover:border-blue-300 dark:hover:border-blue-600',
       movie: 'hover:border-green-300 dark:hover:border-green-600',
       series: 'hover:border-purple-300 dark:hover:border-purple-600',
     };
-    
+
     return `${baseClasses} bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 ${hoverColorMap[buttonType as keyof typeof hoverColorMap]} shadow-md hover:shadow-lg`;
   };
 

--- a/app/hooks/useSearch.ts
+++ b/app/hooks/useSearch.ts
@@ -92,10 +92,7 @@ export function useSearch() {
         console.error('Search error:', error);
 
         // Check if it's a "Movie not found" error
-        if (
-          error instanceof Error &&
-          error.message === 'NOT_FOUND'
-        ) {
+        if (error instanceof Error && error.message === 'NOT_FOUND') {
           setError('NOT_FOUND');
         } else {
           setError(

--- a/app/shared/schemas/omdb.ts
+++ b/app/shared/schemas/omdb.ts
@@ -16,7 +16,10 @@ export const searchResultSchema = z.object({
  */
 export const searchResponseSchema = z.object({
   Search: z.array(searchResultSchema).optional(),
-  totalResults: z.string().transform(val => parseInt(val, 10)).optional(),
+  totalResults: z
+    .string()
+    .transform(val => parseInt(val, 10))
+    .optional(),
   Response: z.enum(['True', 'False']),
   Error: z.string().optional(),
 });

--- a/app/utils/errorBoundary.tsx
+++ b/app/utils/errorBoundary.tsx
@@ -36,7 +36,10 @@ export class ErrorBoundary extends React.Component<
   render() {
     if (this.state.hasError) {
       // Check if it's a "Movie not found" error
-      if (this.state.error?.message === 'Movie not found!' || this.state.error?.message === 'NOT_FOUND') {
+      if (
+        this.state.error?.message === 'Movie not found!' ||
+        this.state.error?.message === 'NOT_FOUND'
+      ) {
         return <MovieNotFoundFallback />;
       }
 


### PR DESCRIPTION
##**Fix dark mode text contrast issues:**
- Change badge text colors from dark:text-white to dark:text-gray-800 for better readability
- Update section titles (h3, h4) to use darker text on colored backgrounds
- Fix IMDb rating, Metascore, and vote count text colors in ratings section
- Improve text contrast for Genre, Director, Writer, Cast, and Production sections
- Update plot text color from dark:text-gray-300 to dark:text-gray-400 for better readability
- Fix "Total Votes" label to use dark:text-gray-800 with bold font weight
- Restore "Additional Information" title to dark:text-white since it's not on colored background

✨ Enhance overall dark mode user experience with proper text contrast